### PR TITLE
Adding pre_tasks to ensure NRPE is removed from base AMI as it conflicts with Nagios install

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,5 +3,10 @@
   hosts: nagios-server
   become: true
   gather_facts: yes
+  pre_tasks:
+    - name: make sure NRPE is not installed
+      package:
+        name: nrpe
+        state: absent
   roles:
     - role: nagios_xi_server


### PR DESCRIPTION
Adding pre_tasks to ensure NRPE is removed from base AMI as it conflicts with Nagios install